### PR TITLE
Create Windows_MSVC_x64 CI job

### DIFF
--- a/.github/workflows/Windows_MSVC_x64.yml
+++ b/.github/workflows/Windows_MSVC_x64.yml
@@ -1,0 +1,45 @@
+name: Windows MSVC x64
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [ opened, synchronize ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+
+    - name: Install latest CMake
+      uses: lukka/get-cmake@latest
+
+    - name: Restore or setup vcpkg
+      uses: lukka/run-vcpkg@v10
+      with:
+        vcpkgGitCommitId: '98f8d00e89fb6a8019c2045cfa1edbe9d92d3405'
+
+    - name: Get CMakePresets.json
+      run: cp Packaging/windows/CMakePresets.json .
+
+    - name: Run CMake consuming CMakePresets.json and vcpkg.json by mean of vcpkg.
+      uses: lukka/run-cmake@v10
+      with:
+        configurePreset: 'ninja-vcpkg-debug'
+        buildPreset: 'ninja-vcpkg-debug'
+        testPreset: 'ninja-vcpkg-debug'
+
+    - name: Upload-Package
+      if: ${{ !env.ACT }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: devilutionx.exe
+        path: build-ninja-vcpkg-debug/devilutionx.exe

--- a/Packaging/windows/CMakePresets.json
+++ b/Packaging/windows/CMakePresets.json
@@ -1,0 +1,63 @@
+{
+	"version": 3,
+	"cmakeMinimumRequired": {
+		"major": 3,
+		"minor": 19,
+		"patch": 0
+	},
+	"configurePresets": [
+		{
+			"name": "ninja-vcpkg",
+			"displayName": "Ninja with VcPkg Configure Settings",
+			"description": "Configure with vcpkg toolchain",
+			"binaryDir": "${sourceDir}/build-${presetName}",
+			"generator": "Ninja",
+			"cacheVariables": {
+				"CMAKE_TOOLCHAIN_FILE": {
+					"type": "FILEPATH",
+					"value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+				}
+			}
+		},
+		{
+			"name": "ninja-vcpkg-debug",
+			"displayName": "Ninja with VcPkg Configure Settings with CMAKE_BUILD_TYPE=RelWithDebInfo",
+			"inherits": "ninja-vcpkg",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Debug"
+			}
+		},
+		{
+			"name": "ninja-vcpkg-relwithdebinfo",
+			"displayName": "Ninja with VcPkg Configure Settings with CMAKE_BUILD_TYPE=RelWithDebInfo",
+			"inherits": "ninja-vcpkg",
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "RelWithDebInfo"
+			}
+		}
+	],
+	"buildPresets": [
+		{
+			"name": "ninja-vcpkg-debug",
+			"configurePreset": "ninja-vcpkg-debug",
+			"displayName": "Build ninja-vcpkg-debug",
+			"description": "Build ninja-vcpkg-debug Configuration"
+		},
+		{
+			"name": "ninja-vcpkg-relwithdebinfo",
+			"configurePreset": "ninja-vcpkg-relwithdebinfo",
+			"displayName": "Build ninja-vcpkg-relwithdebinfo",
+			"description": "Build ninja-vcpkg-relwithdebinfo Configuration"
+		}
+	],
+	"testPresets": [
+		{
+			"name": "ninja-vcpkg-debug",
+			"configurePreset": "ninja-vcpkg-debug"
+		},
+		{
+			"name": "ninja-vcpkg-relwithdebinfo",
+			"configurePreset": "ninja-vcpkg-relwithdebinfo"
+		}
+	]
+}


### PR DESCRIPTION
I'm really not sure why the MinGW CI is failing (no error in output, but haven't tried running it locally either), but considering that you are mainly focused on Windows on MSVC maybe a better option would be to backport the CI job for it instead (You could also just enable AppVeyor since you still have the config file for it, but it isn't as nice as GitHub Actions).

Here is a quick stab at that.